### PR TITLE
add: 상세페이지 데이터 렌더링

### DIFF
--- a/src/components/common/AuthDialog.jsx
+++ b/src/components/common/AuthDialog.jsx
@@ -1,13 +1,6 @@
 import React from "react";
 
-import {
-	Grid,
-	Dialog,
-	DialogContent,
-	Box,
-	TextField,
-	Input,
-} from "@mui/material";
+import { Grid, Dialog, DialogContent, Box, TextField } from "@mui/material";
 
 import styled from "styled-components";
 

--- a/src/components/common/Category.jsx
+++ b/src/components/common/Category.jsx
@@ -6,7 +6,7 @@ const Category = (props) => {
 
 export default Category;
 
-const StyledCategory = styled.button`
+const StyledCategory = styled.span`
 	font-weight: bold;
 	color: #8f8f8f;
 	background-color: #ffffff;
@@ -15,4 +15,7 @@ const StyledCategory = styled.button`
 	text-align: center;
 	letter-spacing: 2px;
 	cursor: pointer;
+
+	display: flex;
+	align-items: center;
 `;

--- a/src/components/detail/Intro.jsx
+++ b/src/components/detail/Intro.jsx
@@ -6,9 +6,7 @@ import Category from "../common/Category";
 import CommonDialog from "../common/CommonDialog";
 import StyledButton from "../common/StyledButton";
 
-import sample from "../../assets/sample.png";
-
-const Intro = ({ ...props }) => {
+const Intro = ({ challenge }) => {
 	const [dialogOpen, setDialogOpen] = useState(false);
 
 	const handleDialogOpen = () => {
@@ -22,18 +20,22 @@ const Intro = ({ ...props }) => {
 		<IntroBox>
 			<IntroContainer>
 				<IntroThumbnail>
-					<img src={sample} alt="Challenge Thumbnail" />
+					<img src={challenge?.imgUrl} alt="Challenge Thumbnail" />
 				</IntroThumbnail>
 				<ContentsContainer>
-					<Title>챌린지 이름</Title>
+					<Title>{challenge?.title}</Title>
 					<CategoryRow>
-						<IntroCategory>카테고리</IntroCategory>
-						<IntroCategory>카테고리</IntroCategory>
+						<IntroCategory>{challenge?.locationType}</IntroCategory>
+						<IntroCategory>{challenge?.category.name}</IntroCategory>
 					</CategoryRow>
 					<SubTitle>진행 기간</SubTitle>
-					<Text>2021. 01. 01 ~ 2021. 12. 31</Text>
+					<Text>
+						{challenge?.startDate} ~ {challenge?.endDate}
+					</Text>
 					<SubTitle>참가 인원</SubTitle>
-					<Text>00 / 10 명</Text>
+					<Text>
+						{challenge?.participants} / {challenge?.limitPerson} 명
+					</Text>
 					<ApplyButton type="button" onClick={handleDialogOpen}>
 						챌린지 참가하기
 					</ApplyButton>
@@ -102,6 +104,7 @@ const CategoryRow = styled.div`
 const IntroCategory = styled(Category)`
 	font-size: 1.4rem;
 	padding: 0.8rem 1.4rem;
+	cursor: default;
 `;
 
 const SubTitle = styled.div`
@@ -114,7 +117,7 @@ const SubTitle = styled.div`
 const Text = styled.div`
 	font-size: 2.4rem;
 	font-weight: bold;
-	line-spacing: 0.2px;
+	letter-spacing: 2px;
 	margin-bottom: 2.4rem;
 `;
 

--- a/src/components/detail/Main.jsx
+++ b/src/components/detail/Main.jsx
@@ -1,35 +1,50 @@
-import React from "react";
-
-import Intro from "./Intro";
-import { Divider, Grid } from "@mui/material";
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
 
 import styled from "styled-components";
+
+import { Divider, Grid } from "@mui/material";
+import Intro from "./Intro";
 import Participant from "./Participant";
 import PlaceMap from "./PlaceMap";
 
 const Main = () => {
+	const params = useParams();
+	const id = Number(params.id);
+	const [challenge, setChallenge] = useState();
+
+	const fetchChallenge = async () => {
+		try {
+			const { data } = await axios.get(`/challenges/${id}`);
+			setChallenge(data);
+		} catch (err) {
+			console.error(err);
+		}
+	};
+
+	useEffect(() => {
+		fetchChallenge();
+	}, []);
+
 	return (
 		<>
-			<Intro />
+			<Intro challenge={challenge} />
 			<Wrapper>
 				<Row>
 					<Title>챌린지 설명</Title>
-					<Text>
-						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Neque, non
-						eget et lectus at sed. Id viverra purus proin vitae. Fusce leo
-						vestibulum condimentum in. Aliquet amet ut felis volutpat a. Libero,
-						auctor nam est mauris dapibus neque. Nisi, eu convallis eget non eu.
-						Bibendum faucibus pellentesque fusce justo mauris tristique congue.
-						Sit id aliquet scelerisque lectus est commodo. Vitae in quisque
-						volutpat vestibulum morbi netus pulvinar.
-					</Text>
+					<Text>{challenge?.description}</Text>
 				</Row>
 				<Row>
 					<Title>챌린지 참가 장소</Title>
-					<AddressText>도로명 주소</AddressText>
-					<MapContainer>
-						<PlaceMap />
-					</MapContainer>
+					<AddressText>{challenge?.address}</AddressText>
+					{challenge?.address ? (
+						<MapContainer>
+							<PlaceMap />
+						</MapContainer>
+					) : (
+						<OnlineText>본 챌린지는 온라인으로 진행됩니다.</OnlineText>
+					)}
 				</Row>
 				<Divider />
 				<Row>
@@ -85,6 +100,15 @@ const Text = styled.div`
 const MapContainer = styled.div`
 	width: 86.2rem;
 	height: 30rem;
-	border-radius: 0.5rem;
 	margin: 0 auto;
+
+	#map {
+		border-radius: 0.5rem;
+	}
+`;
+
+const OnlineText = styled.div`
+	margin: 8rem 0;
+	font-size: 2rem;
+	text-align: center;
 `;

--- a/src/components/home/ChallengeCard.jsx
+++ b/src/components/home/ChallengeCard.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Card, CardContent, CardMedia, CardActionArea } from "@mui/material";
 import Category from "../common/Category";
@@ -9,43 +9,38 @@ import styled from "styled-components";
 import calendar from "../../assets/icons/calendar.png";
 
 const ChallengeCard = ({ ...props }) => {
-	console.log(props.id);
+	const navigate = useNavigate();
+
 	return (
-		<StyledLink to={`/detail/${props.id}`}>
-			<StyledCard>
-				<CardActionArea>
-					<CardMedia component="img" image={props.imgUrl} />
-					<StyledCardContent>
-						<CardTitle>{props.title}</CardTitle>
-						<Row>
-							<CardCategory>{props.category}</CardCategory>
-							<CardCategory>
-								{props.locationType === "ONLINE" ? "온라인" : "오프라인"}
-							</CardCategory>
-						</Row>
-						<Row>
-							<CardIcon>
-								<img src={calendar} alt="Calendar icon" />
-							</CardIcon>
-							<CardDate>
-								{props.startDate} ~ {props.endDate}
-							</CardDate>
-						</Row>
-						<CardMember>
-							현재 {props.participants}/{props.limitPerson} 명이 참여중입니다.
-						</CardMember>
-					</StyledCardContent>
-				</CardActionArea>
-			</StyledCard>
-		</StyledLink>
+		<StyledCard onClick={() => navigate(`/detail/${props.id}`)}>
+			<CardActionArea>
+				<CardMedia component="img" image={props.imgUrl} />
+				<StyledCardContent>
+					<CardTitle>{props.title}</CardTitle>
+					<Row>
+						<CardCategory>{props.category}</CardCategory>
+						<CardCategory>
+							{props.locationType === "ONLINE" ? "온라인" : "오프라인"}
+						</CardCategory>
+					</Row>
+					<Row>
+						<CardIcon>
+							<img src={calendar} alt="Calendar icon" />
+						</CardIcon>
+						<CardDate>
+							{props.startDate} ~ {props.endDate}
+						</CardDate>
+					</Row>
+					<CardMember>
+						현재 {props.participants}/{props.limitPerson} 명이 참여중입니다.
+					</CardMember>
+				</StyledCardContent>
+			</CardActionArea>
+		</StyledCard>
 	);
 };
 
 export default ChallengeCard;
-
-const StyledLink = styled(Link)`
-	text-decoration: none;
-`;
 
 const StyledCard = styled(Card)`
 	height: 36.3rem;

--- a/src/components/home/ChallengeList.jsx
+++ b/src/components/home/ChallengeList.jsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import axios from "axios";
 
-import styled from "styled-components";
-
-import { Box, Grid } from "@mui/material";
+import { Grid } from "@mui/material";
 import ChallengeCard from "./ChallengeCard";
 
 const ChallengeList = () => {
@@ -13,7 +10,6 @@ const ChallengeList = () => {
 	const fetchChallenges = async () => {
 		try {
 			const { data } = await axios.get("/challenges?kind=All");
-			console.log(data);
 			setList(data);
 		} catch (e) {
 			console.error(e);
@@ -25,31 +21,25 @@ const ChallengeList = () => {
 	}, []);
 
 	return (
-		<ListContainer sx={{ width: "100%" }}>
-			<Grid container spacing={4}>
-				{list.map((challenge) => (
-					<Grid item xs={4}>
-						<ChallengeCard
-							key={challenge.challengeId}
-							id={challenge.challengeId}
-							title={challenge.title}
-							category={challenge.category.name}
-							locationType={challenge.locationType}
-							startDate={challenge.startDate}
-							endDate={challenge.endDate}
-							imgUrl={challenge.imgUrl}
-							limitPerson={challenge.limitPerson}
-							participants={challenge.participants}
-						/>
-					</Grid>
-				))}
-			</Grid>
-		</ListContainer>
+		<Grid container spacing={4}>
+			{list.map((challenge) => (
+				<Grid item xs={4} key={challenge.challengeId}>
+					<ChallengeCard
+						key={challenge.challengeId}
+						id={challenge.challengeId}
+						title={challenge.title}
+						category={challenge.category.name}
+						locationType={challenge.locationType}
+						startDate={challenge.startDate}
+						endDate={challenge.endDate}
+						imgUrl={challenge.imgUrl}
+						limitPerson={challenge.limitPerson}
+						participants={challenge.participants}
+					/>
+				</Grid>
+			))}
+		</Grid>
 	);
 };
 
 export default ChallengeList;
-
-const ListContainer = styled(Box)`
-	margin-top: 6rem;
-`;

--- a/src/components/home/Main.jsx
+++ b/src/components/home/Main.jsx
@@ -3,6 +3,8 @@ import axios from "axios";
 
 import styled from "styled-components";
 
+import { Box } from "@mui/material";
+
 import Hero from "./Hero";
 import Contents from "./Contents";
 import SearchBar from "./SearchBar";
@@ -12,10 +14,6 @@ import ChallengeList from "./ChallengeList";
 
 const Main = () => {
 	const [sortBy, setSortBy] = useState("createdAt");
-
-	useEffect(() => {
-		fetchData();
-	}, [sortBy]);
 
 	const fetchData = async () => {
 		try {
@@ -30,6 +28,10 @@ const Main = () => {
 		}
 	};
 
+	useEffect(() => {
+		fetchData();
+	}, [sortBy]);
+
 	return (
 		<>
 			<Hero />
@@ -43,7 +45,9 @@ const Main = () => {
 					<CategoryFilter />
 					<SortFilter sortBy={sortBy} setSortBy={setSortBy} />
 				</FilterRow>
-				<ChallengeList />
+				<ListContainer sx={{ width: "100%" }}>
+					<ChallengeList />
+				</ListContainer>
 			</Wrapper>
 		</>
 	);
@@ -71,4 +75,9 @@ const SearchBarRow = styled.div`
 	margin-top: 3.7rem;
 	display: flex;
 	justify-content: center;
+`;
+
+const ListContainer = styled(Box)`
+	margin-top: 6rem;
+	margin-bottom: 18rem;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,13 +2105,6 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
   integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
 
-"@types/http-proxy@^1.17.5":
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.7.tgz#30ea85cc2c868368352a37f0d0d3581e24834c6f"
-  integrity sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -6110,18 +6103,7 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy-middleware@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz#7ef3417a479fb7666a571e09966c66a39bd2c15f"
-  integrity sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==
-  dependencies:
-    "@types/http-proxy" "^1.17.5"
-    http-proxy "^1.18.1"
-    is-glob "^4.0.1"
-    is-plain-obj "^3.0.0"
-    micromatch "^4.0.2"
-
-http-proxy@^1.17.0, http-proxy@^1.18.1:
+http-proxy@^1.17.0:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -6560,11 +6542,6 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
-
-is-plain-obj@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
-  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
- 공용 카테고리 컴포넌트 StyledCategory button -> span 태그 변경
- 상세페이지에 해당 챌린지 데이터 렌더링
- 챌린지 카드 컴포넌트 클릭 시 상세페이지 이동 라우팅 처리 Link -> useNavigate 변경